### PR TITLE
Use ${var.image_version}, not ${var.version}

### DIFF
--- a/web-service/main.tf
+++ b/web-service/main.tf
@@ -35,7 +35,6 @@ variable "image_version" {
   default     = "latest"
 }
 
-
 variable "subnet_ids" {
   description = "Comma separated list of subnet IDs that will be passed to the ELB module"
 }

--- a/web-service/main.tf
+++ b/web-service/main.tf
@@ -30,10 +30,11 @@ variable "name" {
   default     = ""
 }
 
-variable "version" {
+variable "image_version" {
   description = "The docker image version"
   default     = "latest"
 }
+
 
 variable "subnet_ids" {
   description = "Comma separated list of subnet IDs that will be passed to the ELB module"
@@ -159,7 +160,7 @@ module "task" {
 
   name          = "${coalesce(var.name, replace(var.image, "/", "-"))}"
   image         = "${var.image}"
-  image_version = "${var.version}"
+  image_version = "${var.image_version}"
   command       = "${var.command}"
   env_vars      = "${var.env_vars}"
   memory        = "${var.memory}"


### PR DESCRIPTION
Seems like "version" is protected in the module context.
https://www.terraform.io/docs/configuration/modules.html#version